### PR TITLE
Fix usage of clip in sigmoid function

### DIFF
--- a/neuralfoil/gen2_5_architecture/main.py
+++ b/neuralfoil/gen2_5_architecture/main.py
@@ -21,7 +21,7 @@ _ln_eps: float = np.log(_eps)
 
 
 def _sigmoid(x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
-    x = np.clip(x, _ln_eps, -_ln_eps)  # Clip to suppress overflow
+    x = np.clip(x, -_ln_eps, _ln_eps)  # Clip to suppress overflow
     return 1 / (1 + np.exp(-x))
 
 


### PR DESCRIPTION
The clipping forced the value to zero as the arguments were the wrong way round.

fixes #4
also linked to https://github.com/peterdsharpe/AeroSandbox/issues/155